### PR TITLE
use get_num_float instead of get_num(_int) for the latlong's minute, …

### DIFF
--- a/library/src/gps_parser.c
+++ b/library/src/gps_parser.c
@@ -1247,7 +1247,7 @@ static void get_location( char *str, location_t *location, int type )
 
         location->degrees = get_num( tmp );
         strcpy( tmp, p_tmp );
-        location->minutes = get_num( tmp );
+        location->minutes = get_num_float( tmp );
     }
 
     return;


### PR DESCRIPTION
…which is a double. Currently the minute returned is losing precision.